### PR TITLE
Jitter

### DIFF
--- a/backend_bt/bt_speaker.c
+++ b/backend_bt/bt_speaker.c
@@ -138,8 +138,8 @@ struct bt_audio_connection {
 	int	oss_fd;
 	int	playing;
 	int	buffer_len;
-	uint8_t	buffer[65536];
-#define JITTER_LEN  16384
+	uint8_t	buffer[131072];
+#define JITTER_LEN  65536
 };
 
 static void


### PR DESCRIPTION
This prevents jitter. We may want to make the buffer size configurable, but 64kb is probably a reasonable value (at 44.1kHz, 2channels, 16 bit it is about 371ms, which is high enough to avoid jitter but still does not introduce too much lag).