### PR TITLE
Initialize buffers

### DIFF
--- a/virtual_eq.c
+++ b/virtual_eq.c
@@ -179,7 +179,7 @@ vclient_eq_alloc(struct virtual_client *pvc)
 			pvc->tx_filter_in[x] =
 			    malloc(sizeof(pvc->tx_filter_in[x][0]) * size);
 			pvc->tx_filter_out[x] =
-			    malloc(sizeof(pvc->tx_filter_out[x][0]) * 2 * size);
+			    calloc(2 * size, sizeof(pvc->tx_filter_out[x][0]));
 			if (pvc->tx_filter_in[x] == NULL ||
 			    pvc->tx_filter_out[x] == NULL)
 				goto error;
@@ -189,7 +189,7 @@ vclient_eq_alloc(struct virtual_client *pvc)
 			pvc->rx_filter_in[x] =
 			    malloc(sizeof(pvc->rx_filter_in[x][0]) * size);
 			pvc->rx_filter_out[x] =
-			    malloc(sizeof(pvc->rx_filter_out[x][0]) * 2 * size);
+			    calloc(2 * size, sizeof(pvc->rx_filter_out[x][0]));
 			if (pvc->rx_filter_in[x] == NULL ||
 			    pvc->rx_filter_out[x] == NULL)
 				goto error;


### PR DESCRIPTION
When using equalizer, I sometimes hear a loud noise and then the sound is very silent, like if the limiter kicks in. I suspect that the equalizer accesses uninitialized data somewhere and it looks like this could be the actual culprit: Freshly allocated output buffer is not initialized, but it is accessed before the first block is filled in.

The bug is hard to reproduce, so I am not sure yet if this is the actual bug I have experienced.