### PR TITLE
HAVE_SNDSTAT supports update

### DIFF
--- a/virtual_main.c
+++ b/virtual_main.c
@@ -1734,6 +1734,7 @@ init_sndstat(vprofile_t *ptr)
 	nvlist_t *nvl;
 	nvlist_t *di = NULL;
 	struct sndstat_nvlbuf_arg arg;
+	unsigned int min_rate, max_rate;
 
 	nvl = nvlist_create(0);
 	if (nvl == NULL) {
@@ -1747,12 +1748,27 @@ init_sndstat(vprofile_t *ptr)
 		goto done;
 	}
 
+	nvlist_add_string(di, SNDSTAT_LABEL_PROVIDER, "virtual_oss");
+	nvlist_add_string(di, SNDSTAT_LABEL_DESC, "Virtual OSS");
+	nvlist_add_number(di, SNDSTAT_LABEL_PCHAN, ptr->channels);
+	nvlist_add_number(di, SNDSTAT_LABEL_RCHAN, ptr->channels);
+	min_rate = 8000;
+	max_rate = voss_dsp_sample_rate;
+	if (voss_libsamplerate_enable == 0 ||
+	    min_rate > max_rate)
+		min_rate = max_rate;
+	if (voss_libsamplerate_enable != 0 && max_rate < 96000)
+		max_rate = 96000;
+	nvlist_add_number(di, SNDSTAT_LABEL_PMINRATE, min_rate);
+	nvlist_add_number(di, SNDSTAT_LABEL_PMAXRATE, max_rate);
+	nvlist_add_number(di, SNDSTAT_LABEL_PFMTS, VSUPPORTED_AFMT);
+	nvlist_add_number(di, SNDSTAT_LABEL_RMINRATE, min_rate);
+	nvlist_add_number(di, SNDSTAT_LABEL_RMAXRATE, max_rate);
+	nvlist_add_number(di, SNDSTAT_LABEL_RFMTS, VSUPPORTED_AFMT);
+
 	if (sscanf(ptr->oss_name, "dsp%d", &unit) == 1) {
 		nvlist_add_stringf(di, SNDSTAT_LABEL_DEVNODE,
 		    "pcm%d", unit);
-		nvlist_add_string(di, SNDSTAT_LABEL_DESC, "Virtual OSS");
-		nvlist_add_number(di, SNDSTAT_LABEL_PCHAN, ptr->channels);
-		nvlist_add_number(di, SNDSTAT_LABEL_RCHAN, ptr->channels);
 		nvlist_append_nvlist_array(nvl, SNDSTAT_LABEL_DSPS, di);
 		if (nvlist_error(di) == 0) {
 			nvlist_free_string(di, SNDSTAT_LABEL_DEVNODE);
@@ -1762,9 +1778,6 @@ init_sndstat(vprofile_t *ptr)
 	} else {
 		nvlist_add_string(di, SNDSTAT_LABEL_DEVNODE,
 		    ptr->oss_name);
-		nvlist_add_string(di, SNDSTAT_LABEL_DESC, "Virtual OSS");
-		nvlist_add_number(di, SNDSTAT_LABEL_PCHAN, ptr->channels);
-		nvlist_add_number(di, SNDSTAT_LABEL_RCHAN, ptr->channels);
 		nvlist_append_nvlist_array(nvl, SNDSTAT_LABEL_DSPS, di);
 	}
 


### PR DESCRIPTION
The following fields are added to better deal with format/sampling rate selection:
- pminrate/rminrate
- pmaxrate/rmaxrate
- pfmts/rfmts