### PR TITLE
Fix SNDCTL_DSP_CURRENT_IPTR and SNDCTL_DSP_CURRENT_OPTR sample values.

### DIFF
--- a/virtual_main.c
+++ b/virtual_main.c
@@ -1405,15 +1405,21 @@ vclient_ioctl_oss(struct cuse_dev *pdev, int fflags,
 		break;
 	case SNDCTL_DSP_CURRENT_IPTR:
 		memset(&data.oss_count, 0, sizeof(data.oss_count));
-		/* compute input samples */
+		/* compute input samples per channel */
 		data.oss_count.samples =
 		    vclient_scale(pvc->rx_samples, pvc->sample_rate, voss_dsp_sample_rate);
+		data.oss_count.samples /= pvc->channels;
+		data.oss_count.fifo_samples =
+		    vclient_input_delay(pvc) / (pvc->channels * vclient_sample_bytes(pvc));
 		break;
 	case SNDCTL_DSP_CURRENT_OPTR:
 		memset(&data.oss_count, 0, sizeof(data.oss_count));
-		/* compute input samples */
+		/* compute output samples per channel */
 		data.oss_count.samples =
 		    vclient_scale(pvc->tx_samples, pvc->sample_rate, voss_dsp_sample_rate);
+		data.oss_count.samples /= pvc->channels;
+		data.oss_count.fifo_samples =
+		    vclient_output_delay(pvc) / (pvc->channels * vclient_sample_bytes(pvc));
 		break;
 	case SNDCTL_DSP_GETIPTR:
 		memset(&data.oss_count_info, 0, sizeof(data.oss_count_info));


### PR DESCRIPTION
Current implementation of the `SNDCTL_DSP_CURRENT_IPTR` and `SNDCTL_DSP_CURRENT_OPTR` ioctls reports the _total_ number of samples for all channels. Although the wording of [OSSv4 documentation](http://manuals.opensound.com/developer/SNDCTL_DSP_CURRENT_IPTR.html) is not entirely clear, both OSSv4 and FreeBSD system OSS report the number of samples _per_ channel here.

These changes would make the reported sample values compatible with OSSv4 and FreeBSD. While there I also added the complementary `fifo_samples` field, so it provides the number of queued samples in the buffer now (please check this).

Worked well in my (simple) tests.

Regards

Florian Walpen