### PR TITLE
virtual_oss: Implement SNDCTL_DSP_LOW_WATER ioctl.

### DIFF
--- a/virtual_int.h
+++ b/virtual_int.h
@@ -164,6 +164,7 @@ struct virtual_client {
 	uint64_t tx_timestamp;
 	uint32_t buffer_frags;
 	uint32_t buffer_size;
+	uint32_t low_water;
 	uint32_t rec_delay;
 	uint32_t noise_rem;
 	int	rx_busy;


### PR DESCRIPTION
This allows to set the low water level for poll() / select() in bytes. Useful for non-blocking I/O, or to keep certain buffer levels and maintain stable latency. I have some Jack2 modifications based on this, and would like to stay compatible with virtual_oss.

Implementation details: The low water level is reset to the default of one fragment, when the buffer size changes. This behaves similar to the fixed levels before, except that poll() will now report one fragment of free playback buffer instead of one byte. Unlike FreeBSD OSS there is a range check on the given value, returning an error. The OSSv4 documentation hints at returning the effective value through the argument, but FreeBSD soundcard.h defines this ioctl as write only.

I did some basic testing, works fine AFAICT.

Best regards

Florian Walpen